### PR TITLE
CD process for Vecinos API created

### DIFF
--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -1,0 +1,25 @@
+name: Deploy Vecinos API
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'AppVecinos.API/**'
+jobs:
+  build:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v3 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build API image
+      run: | 
+        docker build --platform linux --tag aminespinoza/coffeeshop:latest -f src/Dockerfile .
+    - name: Publish API image to Docker Hub
+      run: |
+        docker push aminespinoza/coffeeshop:latest


### PR DESCRIPTION
Closes #19 +

This Github Action will deploy the web API to Docker Hub, it means that we'll require an extra layer of security like a Token or something.