### PR TITLE
Modified Github action to get  Continous Integration

### DIFF
--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -26,3 +26,6 @@ jobs:
     - name: Publish API image to Docker Hub
       run: |
         docker push aminespinoza/vecinosapi:${{ env.VERSION }}
+    - name: Confirm process is done
+      run: |
+        echo 'Process is done'

--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -2,7 +2,7 @@ name: Deploy Vecinos API
 
 on:
   push:
-    branches: [ "amin-patch1" ]
+    branches: [ "main" ]
 #    paths:
 #      - 'AppVecinos.API/**'
     
@@ -26,9 +26,7 @@ jobs:
     - name: Build API image
       run: | 
         docker build --platform linux --tag aminespinoza/vecinosapi:latest .
+        
     - name: Publish API image to Docker Hub
       run: |
         docker push aminespinoza/vecinosapi
-    - name: Confirm process is done
-      run: |
-        echo 'Process is done'

--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -28,7 +28,7 @@ jobs:
         docker build --platform linux --tag aminespinoza/vecinosapi:latest .
     - name: Publish API image to Docker Hub
       run: |
-        docker push aminespinoza/vecinosapi:${{ env.VERSION }}
+        docker push aminespinoza/vecinosapi
     - name: Confirm process is done
       run: |
         echo 'Process is done'

--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -2,7 +2,7 @@ name: Deploy Vecinos API
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "amin-patch1" ]
     paths:
       - 'AppVecinos.API/**'
     

--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -3,8 +3,8 @@ name: Deploy Vecinos API
 on:
   push:
     branches: [ "amin-patch1" ]
-    paths:
-      - 'AppVecinos.API/**'
+#    paths:
+#      - 'AppVecinos.API/**'
     
 jobs:
   build:

--- a/.github/workflows/APIdeploy.yml
+++ b/.github/workflows/APIdeploy.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Docker build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: AppVecinos.API/
     steps:
     - name: Check out the repo
       uses: actions/checkout@v3  
@@ -22,7 +25,7 @@ jobs:
         
     - name: Build API image
       run: | 
-        docker build --platform linux --tag aminespinoza/vecinosapi:latest -f AppVecinos.API/Dockerfile .
+        docker build --platform linux --tag aminespinoza/vecinosapi:latest .
     - name: Publish API image to Docker Hub
       run: |
         docker push aminespinoza/vecinosapi:${{ env.VERSION }}

--- a/AppVecinos.API/Dockerfile
+++ b/AppVecinos.API/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
-WORKDIR /AppVecinos.API
+WORKDIR /src
 COPY AppVecinos.API.csproj .
 RUN dotnet restore
 COPY . .

--- a/AppVecinos.API/Dockerfile
+++ b/AppVecinos.API/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
-WORKDIR /AppVecinos.API/
+WORKDIR /AppVecinos.API
 COPY AppVecinos.API.csproj .
 RUN dotnet restore
 COPY . .

--- a/AppVecinos.API/Dockerfile
+++ b/AppVecinos.API/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
-COPY ./AppVecinos.API.csproj .
+COPY AppVecinos.API.csproj .
 RUN dotnet restore
 COPY . .
 

--- a/AppVecinos.API/Dockerfile
+++ b/AppVecinos.API/Dockerfile
@@ -1,7 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
+
+RUN ls -a
+
 COPY AppVecinos.API.csproj .
+
+RUN ls -a
+
 RUN dotnet restore
 COPY . .
 

--- a/AppVecinos.API/Dockerfile
+++ b/AppVecinos.API/Dockerfile
@@ -1,13 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
-WORKDIR /src
-
-RUN ls -a
-
+WORKDIR /AppVecinos.API/
 COPY AppVecinos.API.csproj .
-
-RUN ls -a
-
 RUN dotnet restore
 COPY . .
 

--- a/AppVecinos.API/Dockerfile
+++ b/AppVecinos.API/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
-COPY AppVecinos.API.csproj .
+COPY ./AppVecinos.API.csproj .
 RUN dotnet restore
 COPY . .
 


### PR DESCRIPTION
This pull request includes changes to the `APIdeploy.yml` workflow file to streamline the deployment process for the Vecinos API. The most important changes include commenting out the paths specification for the `push` event, setting a default working directory for the build job, and simplifying the Docker commands for building and pushing the API image.

Changes to workflow configuration:

* [`.github/workflows/APIdeploy.yml`](diffhunk://#diff-a431f0b7c3508b6724ad2ca18de5391871b7729e4bb8c789df4c90b343871095L6-R15): Commented out the paths specification for the `push` event, which previously limited the workflow to changes within the `AppVecinos.API` directory.
* [`.github/workflows/APIdeploy.yml`](diffhunk://#diff-a431f0b7c3508b6724ad2ca18de5391871b7729e4bb8c789df4c90b343871095L6-R15): Added a default working directory for the build job to `AppVecinos.API/`.

Simplification of Docker commands:

* [`.github/workflows/APIdeploy.yml`](diffhunk://#diff-a431f0b7c3508b6724ad2ca18de5391871b7729e4bb8c789df4c90b343871095L25-R32): Simplified the Docker build command by removing the explicit Dockerfile path.
* [`.github/workflows/APIdeploy.yml`](diffhunk://#diff-a431f0b7c3508b6724ad2ca18de5391871b7729e4bb8c789df4c90b343871095L25-R32): Simplified the Docker push command by removing the version tag.